### PR TITLE
Fix breaking changes between JSoup 1.14.2 to 1.15.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.14.2</version>
+            <version>1.15.3</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/com/jagrosh/jlyrics/LyricsClient.java
+++ b/src/main/java/com/jagrosh/jlyrics/LyricsClient.java
@@ -31,7 +31,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Document.OutputSettings;
 import org.jsoup.nodes.Element;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 
 /**
  *
@@ -42,7 +42,7 @@ public class LyricsClient
     private final Config config = ConfigFactory.load();
     private final HashMap<String, Lyrics> cache = new HashMap<>();
     private final OutputSettings noPrettyPrint = new OutputSettings().prettyPrint(false);
-    private final Whitelist newlineWhitelist = Whitelist.none().addTags("br", "p");
+    private final Safelist newlineSafelist = Safelist.none().addTags("br", "p");
     private final Executor executor;
     private final String defaultSource, userAgent;
     private final int timeout;
@@ -178,6 +178,6 @@ public class LyricsClient
     
     private String cleanWithNewlines(Element element)
     {
-        return Jsoup.clean(Jsoup.clean(element.html(), newlineWhitelist), "", Whitelist.none(), noPrettyPrint);
+        return Jsoup.clean(Jsoup.clean(element.html(), newlineSafelist), "", Safelist.none(), noPrettyPrint);
     }
 }


### PR DESCRIPTION
JSoup replaced org.jsoup.safety.Whitelist with org.jsoup.safety.Safelist. Purely a naming change, no difference of functionality ([ref](https://github.com/jhy/jsoup/blob/master/CHANGES#L61-L62)).

This bumps the JSoup version (re: https://github.com/jagrosh/JLyrics/pull/10) and handles the breaking changes. This is needed as the related MusicBot project has recently bumped the JSoup version to 1.15.3 (re: https://github.com/jagrosh/MusicBot/commit/a7be2c4602680cdfc48b7d19cb90cb19b3ba7151) causing runtime errors as it depends on JLyrics, which depends on a different JSoup version