### PR TITLE
Fix Lyrics fetch for AZLyrics and Genius

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.14.2</version>
+            <version>1.15.3</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/com/jagrosh/jlyrics/LyricsClient.java
+++ b/src/main/java/com/jagrosh/jlyrics/LyricsClient.java
@@ -31,7 +31,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Document.OutputSettings;
 import org.jsoup.nodes.Element;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 
 /**
  *
@@ -42,7 +42,7 @@ public class LyricsClient
     private final Config config = ConfigFactory.load();
     private final HashMap<String, Lyrics> cache = new HashMap<>();
     private final OutputSettings noPrettyPrint = new OutputSettings().prettyPrint(false);
-    private final Whitelist newlineWhitelist = Whitelist.none().addTags("br", "p");
+    private final Safelist newlineSafelist = Safelist.none().addTags("br", "p");
     private final Executor executor;
     private final String defaultSource, userAgent;
     private final int timeout;
@@ -178,6 +178,6 @@ public class LyricsClient
     
     private String cleanWithNewlines(Element element)
     {
-        return Jsoup.clean(Jsoup.clean(element.html(), newlineWhitelist), "", Whitelist.none(), noPrettyPrint);
+        return Jsoup.clean(Jsoup.clean(element.html(), newlineSafelist), "", Safelist.none(), noPrettyPrint);
     }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,9 +6,16 @@ lyrics
 
     A-Z Lyrics
     {
+        token
+        {
+            url = "https://www.azlyrics.com/geo.js"
+            text = true
+            select = ""
+            regex = """(?<=\"value\",\s\").*(?=\")"""
+        }
         search
         {
-            url = "https://search.azlyrics.com/search.php?q=%s"
+            url = "https://search.azlyrics.com/search.php?q=%s&x=%s"
             json = false
             select = "a[href*=/lyrics/]"
         }
@@ -30,8 +37,8 @@ lyrics
         }
         parse
         {
-            title = "h1[class^=SongHeader__Title]"
-            author = "a[class*=SongHeader__Artist]"
+            title = "h1[class*=__Title] > span"
+            author = "a[class*=__Artist]"
             content = "div[class^=Lyrics__Container]"
         }
     }


### PR DESCRIPTION
Fix errors from azLyrics and genius (re: #9)
    
To fix test suite errors related to genius, the configuration selectors had to be updated.
    
To fix azLyrics tests, new functionality for fetching tokens was added:
- AZLyrics generates a token that is embedded on the page
- Token does not come from a standard API endpoint, rather, it is inlined in a JS file that then embeds the token on input form elements as a hidden attribute (unfortunately can't extract it from the initial page returned from the server)
- Despite being inlined, the token in the JS file *does* change depending on time / location. 

To resolve this I added an optional "token" config section for AZ lyrics that fetches the token JS file, extracts the token, and then uses it on subsequent requests.