### PR TITLE
Fix output not having line breaks

### DIFF
--- a/src/main/java/com/jagrosh/jlyrics/LyricsClient.java
+++ b/src/main/java/com/jagrosh/jlyrics/LyricsClient.java
@@ -164,7 +164,7 @@ public class LyricsClient
                             url = urlElement.attr("abs:href");
                         if(url==null || url.isEmpty())
                             return null;
-                        doc = Jsoup.connect(url).userAgent(userAgent).timeout(timeout).get();
+                        doc = Jsoup.connect(url).userAgent(userAgent).timeout(timeout).get().outputSettings(noPrettyPrint);
                         Lyrics lyrics = new Lyrics(doc.selectFirst(titleSelector).ownText(),
                                 doc.selectFirst(authorSelector).ownText(),
                                 cleanWithNewlines(doc.selectFirst(contentSelector)),
@@ -238,6 +238,6 @@ public class LyricsClient
 
     private String cleanWithNewlines(Element element)
     {
-        return Jsoup.clean(Jsoup.clean(element.html(), newlineSafelist), "", Safelist.none(), noPrettyPrint);
+        return Jsoup.clean(Jsoup.clean(element.html(), "", newlineSafelist, noPrettyPrint).replace("<p>", "\n"), "", Safelist.none(), noPrettyPrint).trim();
     }
 }


### PR DESCRIPTION
Hi,

this PR aims at fixing some minor formatting issues with the search results content.
Previously, no line breaks were included in the output string, this minor change hopefully fixes it.

Best regards